### PR TITLE
Feature: per-product shipping additional days

### DIFF
--- a/includes/class-wc-frenet.php
+++ b/includes/class-wc-frenet.php
@@ -307,7 +307,18 @@ class WC_Frenet extends WC_Shipping_Method {
                 if (isset($shipping->DeliveryTime))
                     $date=$shipping->DeliveryTime;
 
-                $label = ( 'yes' == $this->display_date ) ? $this->estimating_delivery( $label, $date, $this->additional_time ) : $label;
+                $additional_time = $this->additional_time;
+
+                foreach ($package['contents'] as $value) {
+                    $product = $value['data'];
+                    if ($product->get_meta('shipping_additional_days')) {
+                        if (intval($product->get_meta('shipping_additional_days')) > $additional_time) {
+                            $additional_time = intval($product->get_meta('shipping_additional_days'));
+                        }
+                    }
+                }
+
+                $label = ( 'yes' == $this->display_date ) ? $this->estimating_delivery( $label, $date, $additional_time ) : $label;
                 $cost  = floatval(str_replace(",", ".", (string) $shipping->ShippingPrice));
 
                 array_push(

--- a/woo-shipping-gateway.php
+++ b/woo-shipping-gateway.php
@@ -5,7 +5,7 @@
  * Description: Frenet para WooCommerce
  * Author: Rafael Mancini
  * Author URI: http://www.frenet.com.br
- * Version: 2.1.6
+ * Version: 2.2.0
  * License: GPLv2 or later
  * Text Domain: woo-shipping-gateway
  * Domain Path: languages/
@@ -61,6 +61,28 @@ if ( ! class_exists( 'WC_Frenet_Main' ) ) :
             if ( ! class_exists( 'SimpleXmlElement' ) ) {
                 add_action( 'admin_notices', 'wcfrenet_extensions_missing_notice' );
             }
+
+            function create_delivery_custom_fields() {
+                $args = array(
+                    'id'            => 'shipping_additional_days',
+                    'label'         => __( 'Tempo adicional (dias)', 'cfwc' ),
+                    'class'					=> 'cfwc-custom-field',
+                    'desc_tip'      => true,
+                    'description'   => __( 'Insira o tempo adicional de processamento para entrega, em dias.', 'ctwc' ),
+                );
+                woocommerce_wp_text_input( $args );
+            }
+            add_action( 'woocommerce_product_options_shipping', 'create_delivery_custom_fields' );
+
+            function save_delivery_custom_fields( $post_id ) {
+                $product = wc_get_product( $post_id );
+                
+                $title = isset( $_POST['shipping_additional_days'] ) ? $_POST['shipping_additional_days'] : '';
+                $product->update_meta_data( 'shipping_additional_days', sanitize_text_field( $title ) );
+                
+                $product->save();
+            }
+            add_action( 'woocommerce_process_product_meta', 'save_delivery_custom_fields' );
         }
 
         /**


### PR DESCRIPTION
This pull request adds an option to set additional shipping days to a product too, instead of only having a option to set store-wide additional shipping days settings.

### Changelog
- Added additional shipping days per product using product metatags
- Added a custom field to the WooCommerce product edit page delivery settings