### PR TITLE
Plugin Name

### DIFF
--- a/includes/class-wc-frenet-shipping-simulator.php
+++ b/includes/class-wc-frenet-shipping-simulator.php
@@ -173,12 +173,12 @@ class WC_Frenet_Shipping_Simulator extends WC_Frenet
         $post = $_POST;
         $shippingValues = [];
         if (!self::validateData($post)) {
-            echo json_encode($shippingValues);
+            echo wp_json_encode($shippingValues);
             return;
         } 
 
         if(!($variation = self::getProduct($post))) {
-            echo json_encode($shippingValues);
+            echo wp_json_encode($shippingValues);
             return;
         }
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,5 +1,5 @@
 ﻿
-=== Frenet Shipping Gateway for Woocommece ===
+=== Frenet Shipping Gateway for WooCommerce ===
 Contributors: frenet
 Donate link: http://www.frenet.com.br/
 Tags: shipping, delivery, woocommerce, correios, jamef, jadlog, tnt, braspress

--- a/woo-shipping-gateway.php
+++ b/woo-shipping-gateway.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Plugin Name: Frenet Shipping Gateway for Woocommece
+ * Plugin Name: Frenet Shipping Gateway for WooCommerce
  * Plugin URI: https://github.com/FrenetGatewaydeFretes/woo-shipping-gateway
  * Description: Frenet para WooCommerce
  * Author: Rafael Mancini


### PR DESCRIPTION
Olá Equipe Wordpress

A validação do POST está sendo feita no arquivo woo-shipping-gateway/includes/class-wc-frenet-shipping-simulator.php:175.

if (!self::validateData($post)) {

A cada chama do POST, é feita por metódo onde utilizamos:

self::getParamPost($post, 'zipcode');

Se for feito a validação do código correto, verão que existe o método:

/**
     * Get param
     *
     * @param array $post
     * @param [type] $field
     * @return void
     */
    protected static function getParamPost(array $post, $field)
    {
        return sanitize_text_field($post[$field]);
    }

Está localizado no arquivo woo-shipping-gateway/includes/class-wc-frenet-shipping-simulator.php:161

Pela documentação do wordpress, está correto.

Outro erro apontado é a versão, foi atualizada a versão do plugin e a versão do wordpress colocada no readme é a ultima.