### PR TITLE
Corrigido: CRITICAL Uncaught Error: Cannot use object of type WP_Error as array

### DIFF
--- a/includes/class-wc-frenet.php
+++ b/includes/class-wc-frenet.php
@@ -636,14 +636,16 @@ class WC_Frenet extends WC_Shipping_Method {
                 "Authorization" => $this->token
             ]
         ];
+
         $curlResponse = wp_remote_post($this->urlShipQuote, $paramsRequest);
-        $this->log('Curl response: ' . $curlResponse['body']);
         
         if ( is_wp_error( $curlResponse ) ) {
             $this->log('WP_Error: ' . $curlResponse->get_error_message());
             return $values;
         } 
         
+        $this->log('Curl response: ' . $curlResponse['body']);
+
         $response = json_decode($curlResponse['body']);
         if ( !isset( $response->ShippingSevicesArray ) ) {
             return $values;


### PR DESCRIPTION
Correção na exibição dos logs de erros retornados pela tentativa da chamada da API de cotação da Frenet.
Para gerar os logs em modo de debug no plug, é necessário habilitar a opção de Debug no módulo.