### PR TITLE
Fix: enviando instância na função is_available

### DIFF
--- a/includes/class-wc-frenet.php
+++ b/includes/class-wc-frenet.php
@@ -227,7 +227,7 @@ class WC_Frenet extends WC_Shipping_Method {
 			$is_available = false;
 		}
 
-		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available, $package );
+		return apply_filters( 'woocommerce_shipping_' . $this->id . '_is_available', $is_available, $package, $this );
 	}
 
 	/**

--- a/includes/class-wc-frenet.php
+++ b/includes/class-wc-frenet.php
@@ -30,6 +30,16 @@ class WC_Frenet extends WC_Shipping_Method {
 	}
 
 	/**
+	 * Convert class to string.
+	 *
+	 * @return string Class ID.
+	 */
+	public function __toString()
+	{
+	    return 'WC_Frenet::' . $this->id . '::' . $this->instance_id . '::' . $this->method_title;
+	}
+
+	/**
 	 * Initializes the method.
 	 *
 	 * @return void


### PR DESCRIPTION
Este é o padrão de retorno da função is_available e sem ele não consigo pegar os dados da instância pra aplicar filtro.

Estou criando a limitação do método por classe de entrega para ser compatível com o WCMp. Posso enviar o código, se desejarem.