### PR TITLE
Pequena alteração no simulador

### DIFF
--- a/assets/js/simulator.js
+++ b/assets/js/simulator.js
@@ -139,6 +139,15 @@ jQuery(document).ready(function ($) {
                             shippingSpan.innerText = value.ServiceDescription + ': ';
 
                             shippingLi.appendChild(shippingSpan);
+
+                            /*
+                             Caso haja configuração de desconto no frete na plataforma, o valor original aparece taxado, reforçando a promoção para o cliente/usuário
+                            (https://www.frenet.com.br/blog/criar-regra-de-frete-e-simples-assim/)
+                            */
+                            if(value.OriginalShippingPrice > value.ShippingPrice + 0.1) {
+                                shippingLi.innerText += 'de: <s>R$' + value.OriginalShippingPrice + '</s> por: '
+                            }
+                            
                             shippingLi.innerText += 'R$' + value.ShippingPrice;
 
                             if (response.display_date === true) {


### PR DESCRIPTION
Caso o value.ShippingPrice seja menor que o value.OriginalShippingPrice o valor original é apresentado tachado, reforando a existencia de um desconto no valor da entrega.

[Documentação API](https://frenetapi.docs.apiary.io/#reference/shipping/shippingquote/post)

[Configuração de Desconto na Plataforma](https://www.frenet.com.br/blog/criar-regra-de-frete-e-simples-assim/#:~:text=Regra%20de%20desconto%20por,percentual%20a%20ser%20descontado.)