### PR TITLE
fix: guard against undefined array key 0 in get_coupom

### DIFF
--- a/includes/class-wc-frenet.php
+++ b/includes/class-wc-frenet.php
@@ -401,8 +401,8 @@ class WC_Frenet extends WC_Shipping_Method {
      */
     protected function get_coupom($package) {
         $coupom = "";
-        if (in_array( "applied_coupons", array_keys( $package ) ) && count($package["applied_coupons"]) > 0) {
-            $coupom = $package["applied_coupons"][0];
+        if ( ! empty( $package["applied_coupons"] ) ) {
+            $coupom = reset( $package["applied_coupons"] );
         }
         return $coupom;
     }
@@ -754,6 +754,7 @@ class WC_Frenet extends WC_Shipping_Method {
 
         $response = json_decode($curlResponse['body']);
         if ( !isset( $response->ShippingSevicesArray ) ) {
+            $this->log( 'Frenet response missing ShippingSevicesArray. Raw body: ' . $curlResponse['body'] );
             return $values;
         }
         $servicosArray = (array)$response->ShippingSevicesArray;


### PR DESCRIPTION
The applied_coupons array may have non-sequential keys (e.g. after a coupon is removed via unset), causing "Undefined array key 0" on checkout. Replace the count()+[0] access with reset() which safely retrieves the first element regardless of key structure.

Also log the raw Frenet response body when ShippingSevicesArray is absent, making it easier to diagnose intermittent missing-rate issues.