### PR TITLE
fix: Corrigir sincronização de volume para etiqueta

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Donate link: http://www.frenet.com.br/
 Tags: shipping, delivery, woocommerce, correios, jamef, jadlog, tnt, braspress  
 Requires at least: 3.5  
 Tested up to: 6.9  
-Version: 2.1.22
-Stable tag: 2.1.22 
+Version: 2.1.23
+Stable tag: 2.1.23 
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -336,6 +336,10 @@ SimpleXML extension (already included in PHP 5).
 
 
 == Changelog ==
+
+= 2.1.23 - 06/03/2026 =
+
+* Corrige problema em que os dados de volume (peso, comprimento, largura e altura) não eram salvos no pedido do WooCommerce durante o checkout. Com isso, ao importar o pedido na Frenet para geração de etiqueta, os campos de volume ficavam em branco.
 
 = 2.1.22 - 19/01/2026 =
 

--- a/includes/class-wc-frenet.php
+++ b/includes/class-wc-frenet.php
@@ -92,6 +92,9 @@ class WC_Frenet extends WC_Shipping_Method {
 
 		// Actions.
         add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
+
+		// Save product dimensions to the order shipping item for label generation.
+		add_action( 'woocommerce_checkout_create_order_shipping_item', array( $this, 'save_shipping_item_dimensions' ), 10, 4 );
 	}
 
 	/**
@@ -700,6 +703,84 @@ class WC_Frenet extends WC_Shipping_Method {
         }
 
         return $same_class;
+    }
+
+    /**
+     * Save product dimensions to the order shipping item.
+     * This allows Frenet to use volume data when generating the shipping label.
+     *
+     * @param WC_Order_Item_Shipping $item
+     * @param int                    $package_key
+     * @param array                  $package
+     * @param WC_Order               $order
+     *
+     * @return void
+     */
+    public function save_shipping_item_dimensions( $item, $package_key, $package, $order ) {
+
+        // Check if the chosen method for this package is Frenet.
+        $chosen_methods = WC()->session ? WC()->session->get( 'chosen_shipping_methods' ) : array();
+        if ( ! isset( $chosen_methods[ $package_key ] ) ) {
+            return;
+        }
+
+        if ( strpos( $chosen_methods[ $package_key ], 'frenet' ) === false ) {
+            return;
+        }
+
+        $total_weight = 0.0;
+        $max_length   = 0.0;
+        $max_width    = 0.0;
+        $total_height = 0.0;
+
+        foreach ( $package['contents'] as $values ) {
+            $product = $values['data'];
+            $qty     = (int) $values['quantity'];
+
+            if ( $qty <= 0 || ! $product->needs_shipping() ) {
+                continue;
+            }
+
+            if ( version_compare( WOOCOMMERCE_VERSION, '3.0', '>=' ) ) {
+                $_weight = (float) wc_get_weight( $this->fix_format( $product->get_weight() ), 'kg' );
+                $_length = (float) wc_get_dimension( $this->fix_format( $product->get_length() ), 'cm' );
+                $_width  = (float) wc_get_dimension( $this->fix_format( $product->get_width() ), 'cm' );
+                $_height = (float) wc_get_dimension( $this->fix_format( $product->get_height() ), 'cm' );
+            } else {
+                $_weight = (float) wc_get_weight( $this->fix_format( $product->weight ), 'kg' );
+                $_length = (float) wc_get_dimension( $this->fix_format( $product->length ), 'cm' );
+                $_width  = (float) wc_get_dimension( $this->fix_format( $product->width ), 'cm' );
+                $_height = (float) wc_get_dimension( $this->fix_format( $product->height ), 'cm' );
+            }
+
+            if ( empty( $_weight ) ) $_weight = 1.0;
+            if ( empty( $_length ) ) $_length = (float) $this->minimum_length;
+            if ( empty( $_width ) )  $_width  = (float) $this->minimum_width;
+            if ( empty( $_height ) ) $_height = (float) $this->minimum_height;
+
+            $total_weight += $_weight * $qty;
+            $max_length    = max( $max_length, $_length );
+            $max_width     = max( $max_width, $_width );
+            $total_height += $_height * $qty;
+        }
+
+        $item->add_meta_data( '_frenet_volume_weight', round( $total_weight, 3 ) );
+        $item->add_meta_data( '_frenet_volume_length', round( $max_length, 2 ) );
+        $item->add_meta_data( '_frenet_volume_width',  round( $max_width, 2 ) );
+        $item->add_meta_data( '_frenet_volume_height', round( $total_height, 2 ) );
+
+        if ( 'yes' === $this->debug ) {
+            $this->log->add(
+                $this->id,
+                sprintf(
+                    'Dimensions saved to shipping item: Weight=%.3f kg | Length=%.2f cm | Width=%.2f cm | Height=%.2f cm',
+                    round( $total_weight, 3 ),
+                    round( $max_length, 2 ),
+                    round( $max_width, 2 ),
+                    round( $total_height, 2 )
+                )
+            );
+        }
     }
 
     /**

--- a/readme.txt
+++ b/readme.txt
@@ -4,8 +4,8 @@ Donate link: http://www.frenet.com.br/
 Tags: shipping, delivery, woocommerce, correios, jamef, jadlog, tnt, braspress  
 Requires at least: 3.5  
 Tested up to: 6.9
-Version: 2.1.22
-Stable tag: 2.1.22 
+Version: 2.1.23
+Stable tag: 2.1.23 
 License: GPLv2 or later  
 License URI: http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -336,6 +336,10 @@ SimpleXML extension (already included in PHP 5).
 
 
 == Changelog ==
+
+= 2.1.23 - 06/03/2026 =
+
+* Corrige problema em que os dados de volume (peso, comprimento, largura e altura) não eram salvos no pedido do WooCommerce durante o checkout. Com isso, ao importar o pedido na Frenet para geração de etiqueta, os campos de volume ficavam em branco.
 
 = 2.1.22 - 19/01/2026 =
 

--- a/woo-shipping-gateway.php
+++ b/woo-shipping-gateway.php
@@ -5,7 +5,7 @@
  * Description: Frenet para WooCommerce
  * Author: Rafael Mancini
  * Author URI: http://www.frenet.com.br
- * Version: 2.1.22
+ * Version: 2.1.23
  * License: GPLv2 or later
  * Text Domain: woo-shipping-gateway
  * Domain Path: languages/
@@ -45,7 +45,7 @@ if ( ! class_exists( 'WC_Frenet_Main' ) ) :
          *
          * @var string
          */
-        const VERSION = '2.1.22';
+        const VERSION = '2.1.23';
 
         /**
          * Instance of this class.


### PR DESCRIPTION
### Descrição do PR

Corrige problema em que os dados de volume (peso, comprimento, largura e altura) não eram salvos no pedido do WooCommerce durante o checkout. Com isso, ao importar o pedido na Frenet para geração de etiqueta, os campos de volume ficavam em branco.
### O que foi feito

- Salvamento correto dos campos de volume no pedido ao finalizar o checkout.
- Mapeamento dos campos para o formato esperado pela Frenet antes da importação.
- Testes manuais cobrindo cenários de produto com e sem dimensões preenchidas.

### Por que isso importa

Sem esses dados, a Frenet recebia pedidos com campos de volume vazios, impedindo a geração correta de etiquetas e podendo causar erros no processo de envio.
### Como testar

- Criar um pedido no WooCommerce com produto contendo peso, comprimento, largura e altura preenchidos.
- Finalizar checkout e verificar que os campos de volume foram salvos no pedido (admin > pedidos).
- Importar o pedido na Frenet e confirmar que os campos de volume aparecem corretamente na interface/importação.
- Repetir com produto sem dimensões — deve seguir comportamento esperado (ex.: fallback ou aviso).

